### PR TITLE
rotate video 90 deg

### DIFF
--- a/FFmpeg.Core/Models/RotateModel.cs
+++ b/FFmpeg.Core/Models/RotateModel.cs
@@ -1,0 +1,11 @@
+﻿namespace FFmpeg.Core.Models
+{
+    public class RotateModel
+    {
+        public string InputFile { get; set; }
+        public string OutputFile { get; set; }
+        public double RotationAngle { get; set; } 
+        public bool IsVideo { get; set; }
+        public string VideoCodec { get; set; } = "libx264"; 
+    }
+}

--- a/FFmpeg.Infrastructure/Commands/RotateCommand.cs
+++ b/FFmpeg.Infrastructure/Commands/RotateCommand.cs
@@ -1,0 +1,37 @@
+﻿using FFmpeg.Core.Models;
+using FFmpeg.Infrastructure.Commands;
+using FFmpeg.Infrastructure.Services;
+using System;
+using System.Threading.Tasks;
+namespace Ffmpeg.Command.Commands
+{
+    public class RotateCommand : BaseCommand, ICommand<RotateModel>
+    {
+        private readonly ICommandBuilder _commandBuilder;
+
+        public RotateCommand(FFmpegExecutor executor, ICommandBuilder commandBuilder)
+            : base(executor)
+        {
+            _commandBuilder = commandBuilder ?? throw new ArgumentNullException(nameof(commandBuilder));
+        }
+
+        public async Task<CommandResult> ExecuteAsync(RotateModel model)
+        {
+            double radians = model.RotationAngle * Math.PI / 180.0;
+            string rotationFilter = $"rotate={radians}";
+
+            CommandBuilder = _commandBuilder
+                .SetInput(model.InputFile)
+                .AddOption($"-vf \"{rotationFilter}\"");
+
+            if (model.IsVideo)
+            {
+                CommandBuilder.SetVideoCodec(model.VideoCodec);
+            }
+
+            CommandBuilder.SetOutput(model.OutputFile, model.IsVideo ? false : true);
+
+            return await RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
Description: Rotates the video by a certain angle.
Command in ffmpeg:
ffmpeg -i input.mp4 -vf "rotate=90*PI/180" output.mp4 (rotate by 90 degrees)
Required input:
Video name, rotation angle, video output name.