### PR TITLE
add black-and-white-filter command

### DIFF
--- a/FFmpeg.Core/Models/BlackAndWhiteModel.cs
+++ b/FFmpeg.Core/Models/BlackAndWhiteModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Core.Models
+{
+    public class BlackAndWhiteModel
+    {
+        public string InputFile { get; set; }
+        public string OutputFile { get; set; }
+    }
+}

--- a/FFmpeg.Infrastructure/Commands/BlackAndWhiteCommand.cs
+++ b/FFmpeg.Infrastructure/Commands/BlackAndWhiteCommand.cs
@@ -1,0 +1,32 @@
+﻿using Ffmpeg.Command.Commands;
+using FFmpeg.Core.Models;
+using FFmpeg.Infrastructure.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Infrastructure.Commands
+{
+    public class BlackAndWhiteCommand : BaseCommand, ICommand<BlackAndWhiteModel>
+    {
+        private readonly ICommandBuilder _commandBuilder;
+
+        public BlackAndWhiteCommand(FFmpegExecutor executor, ICommandBuilder commandBuilder)
+            : base(executor)
+        {
+            _commandBuilder = commandBuilder ?? throw new ArgumentNullException(nameof(commandBuilder));
+        }
+
+        public async Task<CommandResult> ExecuteAsync(BlackAndWhiteModel model)
+        {
+            CommandBuilder = _commandBuilder
+                .SetInput(model.InputFile)
+                .AddFilterComplex("hue=s=0")
+                .SetOutput(model.OutputFile);
+
+            return await RunAsync();
+        }
+    }
+}

--- a/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
+++ b/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
@@ -14,6 +14,8 @@ namespace FFmpeg.Infrastructure.Services
     public interface IFFmpegServiceFactory
     {
         ICommand<WatermarkModel> CreateWatermarkCommand();
+        ICommand<BlackAndWhiteModel> CreateBlackAndWhiteCommand();
+
     }
 
     public class FFmpegServiceFactory : IFFmpegServiceFactory
@@ -35,6 +37,10 @@ namespace FFmpeg.Infrastructure.Services
         public ICommand<WatermarkModel> CreateWatermarkCommand()
         {
             return new WatermarkCommand(_executor, _commandBuilder);
+        }
+        public ICommand<BlackAndWhiteModel> CreateBlackAndWhiteCommand()
+        {
+            return new BlackAndWhiteCommand(_executor, _commandBuilder);
         }
     }
 }


### PR DESCRIPTION
Changes Made:

Added BlackAndWhiteCommand class under FFmpeg.Infrastructure.Commands

Extended FFmpegServiceFactory to support CreateBlackAndWhiteCommand() returning ICommand<BlackAndWhiteModel>

Introduced BlackAndWhiteModel in FFmpeg.Core.Models 