### PR TITLE
 Add FFmpeg Video Format Conversion Command

### DIFF
--- a/FFmpeg.Core/Models/ConvertFormatModel.cs
+++ b/FFmpeg.Core/Models/ConvertFormatModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Core.Models
+{
+    public class ConvertFormatModel
+    {
+        public string InputFile { get; set; }
+        public string OutputFile { get; set; }
+        public string? VideoCodec { get; set; } 
+    }
+}

--- a/FFmpeg.Infrastructure/Commands/ConvertFormatCommand.cs
+++ b/FFmpeg.Infrastructure/Commands/ConvertFormatCommand.cs
@@ -1,0 +1,37 @@
+﻿using Ffmpeg.Command.Commands;
+using FFmpeg.Core.Models;
+using FFmpeg.Infrastructure.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Infrastructure.Commands
+{
+    public class ConvertFormatCommand : BaseCommand, ICommand<ConvertFormatModel>
+    {
+        private readonly ICommandBuilder _commandBuilder;
+
+        public ConvertFormatCommand(FFmpegExecutor executor, ICommandBuilder commandBuilder)
+            : base(executor)
+        {
+            _commandBuilder = commandBuilder ?? throw new ArgumentNullException(nameof(commandBuilder));
+        }
+
+        public async Task<CommandResult> ExecuteAsync(ConvertFormatModel model)
+        {
+            CommandBuilder = _commandBuilder
+                .SetInput(model.InputFile);
+
+            if (!string.IsNullOrEmpty(model.VideoCodec))
+            {
+                CommandBuilder.SetVideoCodec(model.VideoCodec);
+            }
+
+            CommandBuilder.SetOutput(model.OutputFile);
+
+            return await RunAsync();
+        }
+    }
+}

--- a/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
+++ b/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
@@ -21,7 +21,6 @@ namespace FFmpeg.Infrastructure.Services
         ICommand<ConvertAudioModel> CreateConvertAudioCommand();
         ICommand<FadeEffectModel> CreateFadeEffectCommand();
         ICommand<ConvertFormatModel> CreateConvertFormatCommand();
-
     }
 
     public class FFmpegServiceFactory : IFFmpegServiceFactory

--- a/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
+++ b/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
@@ -20,6 +20,8 @@ namespace FFmpeg.Infrastructure.Services
         ICommand<AudioEffectModel> CreateAudioEffectCommand();
         ICommand<ConvertAudioModel> CreateConvertAudioCommand();
         ICommand<FadeEffectModel> CreateFadeEffectCommand();
+        ICommand<ConvertFormatModel> CreateConvertFormatCommand();
+
     }
 
     public class FFmpegServiceFactory : IFFmpegServiceFactory
@@ -70,6 +72,11 @@ namespace FFmpeg.Infrastructure.Services
         public ICommand<ConvertAudioModel> CreateConvertAudioCommand()
         {
             return new ConvertAudioCommand(_executor, _commandBuilder);
+        }
+
+        public ICommand<ConvertFormatModel> CreateConvertFormatCommand()
+        {
+            return new ConvertFormatCommand(_executor, _commandBuilder);
         }
     }
 }

--- a/Ffmpeg.API/DTOs/ConvertFormatDto.cs
+++ b/Ffmpeg.API/DTOs/ConvertFormatDto.cs
@@ -1,0 +1,8 @@
+﻿namespace FFmpeg.API.DTOs
+{
+    public class ConvertFormatDto
+    {
+        public IFormFile InputFile { get; set; }
+        public string OutputFileName { get; set; }
+    }
+}

--- a/Ffmpeg.API/Endpoints/VideoEndpoints.cs
+++ b/Ffmpeg.API/Endpoints/VideoEndpoints.cs
@@ -50,7 +50,7 @@ namespace FFmpeg.API.Endpoints
                 .WithMetadata(new RequestSizeLimitAttribute(104857600)); // 100 MB
             app.MapPost("/api/video/convertformat", ConvertVideoFormat)
                 .DisableAntiforgery()
-                .WithMetadata(new RequestSizeLimitAttribute(104857600));
+                .WithMetadata(new RequestSizeLimitAttribute(MaxUploadSize));
         }
 
         private static async Task<IResult> ReverseVideo(
@@ -486,6 +486,5 @@ namespace FFmpeg.API.Endpoints
                 return Results.Problem("An error occurred: " + ex.Message, statusCode: 500);
             }
         }
-
     }
 }


### PR DESCRIPTION
This PR adds support for converting video files from one format to another using FFmpeg 
(e.g., MP4 to AVI).

✨ Details:
- Created `ConvertFormatModel` and `ConvertFormatDto`
- Implemented `ConvertFormatCommand` to run: ffmpeg -i input output
- Updated `FFmpegServiceFactory` to register the new command
- Added new API endpoint: POST /api/video/convertformat
- Utilized `IFileService` for file upload, storage, cleanup, and output retrieval
- Returns the converted file as downloadable response

🧪 Tested manually with MP4 input converted to AVI – works as expected and returns file.

Good luck reviewing and thank you! 😊